### PR TITLE
Feat: create model order

### DIFF
--- a/src/main/java/com/ada/order/model/Order.java
+++ b/src/main/java/com/ada/order/model/Order.java
@@ -1,0 +1,40 @@
+package com.ada.order.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity(name = "order")
+@Table(name = "orders")
+public class Order {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(nullable = false)
+  private String cpfUser;
+
+  private LocalDateTime requestDate;
+
+  @Column(nullable = false)
+  private TypeCurrency typeCurrency;
+
+  @Column(nullable = false)
+  private BigDecimal valueForeignCurrency;
+
+  private BigDecimal quotationValue;
+
+  private BigDecimal valueTotalOperation;
+
+  @Column(nullable = false)
+  private String withdrawalAgencyNumber;
+}

--- a/src/main/java/com/ada/order/model/TypeCurrency.java
+++ b/src/main/java/com/ada/order/model/TypeCurrency.java
@@ -1,0 +1,6 @@
+package com.ada.order.model;
+
+public enum TypeCurrency {
+  USD,
+  EUR
+}


### PR DESCRIPTION
## Objetivo #6 
Adicionar a `Entity Order` junto com o JPA para persistência de dados no H2, no qual está responsável por criar a tabela `orders `no H2.

```JAVA
public class Order {
  @Id
  @GeneratedValue(strategy = GenerationType.IDENTITY)
  private Integer id;

  @Column(nullable = false)
  private String cpfUser;

  private LocalDateTime requestDate;

  @Column(nullable = false)
  private TypeCurrency typeCurrency;

  @Column(nullable = false)
  private BigDecimal valueForeignCurrency;

  private BigDecimal quotationValue;

  private BigDecimal valueTotalOperation;

  @Column(nullable = false)
  private String withdrawalAgencyNumber;
}
```

- [x] Foi testado localmente uma order no H2